### PR TITLE
fix 422 by sending JSON content-type header

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -26,6 +26,7 @@
             
             fetch("/classify", {
                 method: "POST",
+                headers: {"Content-Type": "application/json"},
                 body: JSON.stringify({text})
             })
             .then(res => res.json())


### PR DESCRIPTION
What: Add Content-Type: application/json header to classify request

Why: FastAPI Pydantic body binding requires JSON content-type

Test: Pytest locally + CI should pass